### PR TITLE
use makefile conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ build: install-deps  ## Compiles the program
 	GOPATH=$$(pwd) go build -o vc src/*.go
 
 install: build  ## Install vault-client
-	install -Dm755 vc /usr/bin/vc
-	install -Dm644 sample/vc-completion.bash /usr/share/bash-completion/completion/vc
+	install -Dm755 vc $(DESTDIR)$(bindir)/vc
+	install -Dm644 sample/vc-completion.bash $(DESTDIR)$(datarootdir)/bash-completion/completion/vc


### PR DESCRIPTION
Use makefile conventions like described in the [manual](https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html#Makefile-Conventions).
Expected behaviour:
```Bash
make DESTDIR=/tmp/stage install
```
should install vc to ``/tmp/stage/usr/bin/vc``.
Actual behaviour:
vc is installed to ``/usr/bin/vc``.