### PR TITLE
Fixed vault auth token retrieval error messages

### DIFF
--- a/src/auth.go
+++ b/src/auth.go
@@ -43,9 +43,9 @@ func GetAuthenticationToken(ui cli.Ui) (string, error) {
 
 	res, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("Unable retrieve authentication token from vault %q", err)
+		return "", fmt.Errorf("Unable to retrieve authentication token from vault %q", err)
 	} else if res.StatusCode != 200 {
-		return "", fmt.Errorf("Unable retrieve authentication token from vault (status code %q)", res.StatusCode)
+		return "", fmt.Errorf("Unable to retrieve authentication token from vault (status code %d)", res.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
The status code was interpreted as a rune instead of a number.
This patch fixes the format string and also adds a missing "to".