### PR TITLE
Add test isolation

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	Path        string
 }
 
-func LoadConfig() error {
+func LoadConfig() (Config, error) {
 
 	cfg = Config{
 		Host:        "127.0.0.1",
@@ -39,12 +39,12 @@ func LoadConfig() error {
 
 	cfg.Path, err = GetConfigPath()
 	if err != nil {
-		return err
+		return cfg, err
 	}
 
 	file, err := os.Stat(cfg.Path)
 	if err != nil {
-		return err
+		return cfg, err
 	}
 
 	config_file_permissions := file.Mode().String()
@@ -52,20 +52,20 @@ func LoadConfig() error {
 	// Check that the config file is only readable by the user.
 	// And not by his group or others (-rwx------)
 	if !strings.HasSuffix(config_file_permissions, "------") {
-		return fmt.Errorf("Your ~/.vaultrc is accessible for others (chmod 700 ~/.vaultrc)")
+		return cfg, fmt.Errorf("Your ~/.vaultrc is accessible for others (chmod 700 ~/.vaultrc)")
 	}
 
 	content, err := ioutil.ReadFile(cfg.Path)
 	if err != nil {
-		return err
+		return cfg, err
 	}
 
 	err = yaml.Unmarshal(content, &cfg)
 	if err != nil {
-		return err
+		return cfg, err
 	}
 
-	return nil
+	return cfg, nil
 }
 
 func ComposeUrl() string {

--- a/src/copy_test.go
+++ b/src/copy_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestCopy(t *testing.T) {
 
-	err := LoadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-	}
-
-	err = InitializeClient()
+	var err error
+	cfg, vc, err = SetupTestEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -27,7 +23,7 @@ func TestCopy(t *testing.T) {
 	t.Run("TooFewArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/insertedsecret",
+			TestBackend + "/insertedsecret",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -43,8 +39,8 @@ func TestCopy(t *testing.T) {
 	t.Run("CopyNonexistentSourceSecret", func(t *testing.T) {
 
 		args := []string{
-			"secret/nonexistensecret",
-			"secret/destinationsecret",
+			TestBackend + "/nonexistensecret",
+			TestBackend + "/destinationsecret",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -63,14 +59,14 @@ func TestCopy(t *testing.T) {
 		data := make(map[string]interface{})
 		data["key"] = "value"
 
-		_, err = vc.Logical().Write("secret/existent", data)
+		_, err = vc.Logical().Write(TestBackend+"/existent", data)
 		if err != nil {
 			t.Fatalf("Unable to write test secret: %q", err)
 		}
 
 		args := []string{
-			"secret/existent",
-			"secret/destinationsecret",
+			TestBackend + "/existent",
+			TestBackend + "/destinationsecret",
 		}
 
 		if rc := c.Run(args); rc != 0 {
@@ -83,8 +79,8 @@ func TestCopy(t *testing.T) {
 		}
 	})
 
-	_, err = vc.Logical().Delete("secret/destinationsecret")
+	err = TeardownTestEnvironment()
 	if err != nil {
-		t.Fatalf("Unable to clean up test secret: %q", err)
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 }

--- a/src/delete_test.go
+++ b/src/delete_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestDelete(t *testing.T) {
 
-	err := LoadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-	}
-
-	err = InitializeClient()
+	var err error
+	cfg, vc, err = SetupTestEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -27,8 +23,8 @@ func TestDelete(t *testing.T) {
 	t.Run("TooManyArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/doesntexist",
-			"secret/toomucharguments",
+			TestBackend + "/doesntexist",
+			TestBackend + "/toomucharguments",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -43,7 +39,7 @@ func TestDelete(t *testing.T) {
 
 	t.Run("NonexistentSecret", func(t *testing.T) {
 
-		args := []string{"secret/doesntexist"}
+		args := []string{TestBackend + "/doesntexist"}
 
 		if rc := c.Run(args); rc != 1 {
 			t.Fatalf("Wrong exit code. errors: \n%s", ui.ErrorWriter.String())
@@ -61,7 +57,7 @@ func TestDelete(t *testing.T) {
 		data := make(map[string]interface{})
 		data["key"] = "value"
 
-		_, err = vc.Logical().Write("secret/existent", data)
+		_, err = vc.Logical().Write(TestBackend+"/existent", data)
 		if err != nil {
 			t.Fatalf("Unable to write test secret: %q", err)
 		}
@@ -69,7 +65,7 @@ func TestDelete(t *testing.T) {
 		ui := new(cli.MockUi)
 		c := &DeleteCommand{Ui: ui}
 
-		args := []string{"secret/existent"}
+		args := []string{TestBackend + "/existent"}
 
 		if rc := c.Run(args); rc != 0 {
 			t.Fatalf("Wrong exit code. errors: \n%s", ui.ErrorWriter.String())
@@ -80,6 +76,10 @@ func TestDelete(t *testing.T) {
 		if actual := ui.ErrorWriter.String(); !strings.Contains(actual, expected) {
 			t.Fatalf("expected:\n%s\n\nto include: %q", actual, expected)
 		}*/
-
 	})
+
+	err = TeardownTestEnvironment()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
 }

--- a/src/edit_test.go
+++ b/src/edit_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestEdit(t *testing.T) {
 
-	err := LoadConfig()
+	_, err := LoadConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}

--- a/src/insert_test.go
+++ b/src/insert_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestInsert(t *testing.T) {
 
-	err := LoadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-	}
-
-	err = InitializeClient()
+	var err error
+	cfg, vc, err = SetupTestEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -27,7 +23,7 @@ func TestInsert(t *testing.T) {
 	t.Run("TooFewArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/insertedsecret",
+			TestBackend + "/insertedsecret",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -43,7 +39,7 @@ func TestInsert(t *testing.T) {
 	t.Run("InsertInvalidKvArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/insertedsecret",
+			TestBackend + "/insertedsecret",
 			"invalidkey: invalidvalue",
 		}
 
@@ -60,7 +56,7 @@ func TestInsert(t *testing.T) {
 	t.Run("InsertValidKvArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/insertedsecret",
+			TestBackend + "/insertedsecret",
 			"invalidkey=invalidvalue",
 		}
 
@@ -74,8 +70,8 @@ func TestInsert(t *testing.T) {
 		}
 	})
 
-	_, err = vc.Logical().Delete("secret/insertedsecret")
+	err = TeardownTestEnvironment()
 	if err != nil {
-		t.Fatalf("Unable to clean up test secret: %q", err)
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -16,13 +16,14 @@ var cfg Config
 
 func main() {
 
-	err := LoadConfig()
+	_, err := LoadConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 
-	err = InitializeClient()
+	_, err = InitializeClient()
+
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -38,7 +39,7 @@ func main() {
 	os.Exit(exitStatus)
 }
 
-func InitializeClient() error {
+func InitializeClient() (*vault.Client, error) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.VerifyTLS},
@@ -54,12 +55,12 @@ func InitializeClient() error {
 
 	vc, err = vault.NewClient(&config)
 	if err != nil {
-		return err
+		return vc, err
 	}
 
 	vc.SetToken(cfg.Token)
 	vc.Auth()
-	return nil
+	return vc, nil
 }
 
 func LoadCli() *cli.CLI {

--- a/src/move_test.go
+++ b/src/move_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestMove(t *testing.T) {
 
-	err := LoadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-	}
-
-	err = InitializeClient()
+	var err error
+	cfg, vc, err = SetupTestEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -27,7 +23,7 @@ func TestMove(t *testing.T) {
 	t.Run("TooFewArgs", func(t *testing.T) {
 
 		args := []string{
-			"secret/insertedsecret",
+			TestBackend + "/insertedsecret",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -43,8 +39,8 @@ func TestMove(t *testing.T) {
 	t.Run("MoveNonexistentSourceSecret", func(t *testing.T) {
 
 		args := []string{
-			"secret/nonexistensecret",
-			"secret/destinationsecret",
+			TestBackend + "/nonexistensecret",
+			TestBackend + "/destinationsecret",
 		}
 
 		if rc := c.Run(args); rc != 1 {
@@ -63,14 +59,14 @@ func TestMove(t *testing.T) {
 		data := make(map[string]interface{})
 		data["key"] = "value"
 
-		_, err = vc.Logical().Write("secret/existent", data)
+		_, err = vc.Logical().Write(TestBackend+"/existent", data)
 		if err != nil {
 			t.Fatalf("Unable to write test secret: %q", err)
 		}
 
 		args := []string{
-			"secret/existent",
-			"secret/destinationsecret",
+			TestBackend + "/existent",
+			TestBackend + "/destinationsecret",
 		}
 
 		if rc := c.Run(args); rc != 0 {
@@ -83,8 +79,8 @@ func TestMove(t *testing.T) {
 		}
 	})
 
-	_, err = vc.Logical().Delete("secret/destinationsecret")
+	err = TeardownTestEnvironment()
 	if err != nil {
-		t.Fatalf("Unable to clean up test secret: %q", err)
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 }

--- a/src/show_test.go
+++ b/src/show_test.go
@@ -11,12 +11,8 @@ import (
 
 func TestShow(t *testing.T) {
 
-	err := LoadConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-	}
-
-	err = InitializeClient()
+	var err error
+	cfg, vc, err = SetupTestEnvironment()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -26,7 +22,7 @@ func TestShow(t *testing.T) {
 
 	t.Run("ShowNonexistentSecret", func(t *testing.T) {
 
-		args := []string{"secret/secret2"}
+		args := []string{TestBackend + "/secret2"}
 
 		if rc := c.Run(args); rc != 1 {
 			t.Fatalf("Wrong exit code. errors: \n%s", ui.ErrorWriter.String())
@@ -49,12 +45,12 @@ func TestShow(t *testing.T) {
 		data := make(map[string]interface{})
 		data["key"] = "value"
 
-		_, err = vc.Logical().Write("secret/secret1", data)
+		_, err = vc.Logical().Write(TestBackend+"/secret1", data)
 		if err != nil {
 			t.Fatalf("Unable to write test secret: %q", err)
 		}
 
-		args := []string{"secret/secret1"}
+		args := []string{TestBackend + "/secret1"}
 
 		if rc := c.Run(args); rc != 0 {
 			t.Fatalf("Wrong exit code. errors: \n%s", ui.ErrorWriter.String())
@@ -79,12 +75,12 @@ func TestShow(t *testing.T) {
 		data["c_key"] = "value"
 		data["b_key"] = "value"
 
-		_, err = vc.Logical().Write("secret/secret1", data)
+		_, err = vc.Logical().Write(TestBackend+"/secret1", data)
 		if err != nil {
 			t.Fatalf("Unable to write test secret: %q", err)
 		}
 
-		args := []string{"secret/secret1"}
+		args := []string{TestBackend + "/secret1"}
 
 		if rc := c.Run(args); rc != 0 {
 			t.Fatalf("Wrong exit code. errors: \n%s", ui.ErrorWriter.String())
@@ -103,8 +99,8 @@ c_key: value`
 		}
 	})
 
-	_, err = vc.Logical().Delete("secret/secret1")
+	err = TeardownTestEnvironment()
 	if err != nil {
-		t.Fatalf("Unable to write test secret: %q", err)
+		fmt.Fprintln(os.Stderr, err.Error())
 	}
 }

--- a/src/test_helper.go
+++ b/src/test_helper.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	vault "github.com/hashicorp/vault/api"
+)
+
+const TestBackend = "/test"
+
+func SetupTestEnvironment() (Config, *vault.Client, error) {
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	client, err := InitializeClient()
+	if err != nil {
+		return cfg, client, err
+	}
+
+	mountConfig := vault.MountInput{
+		Type:        "kv",
+		Description: "vault-client integration tests",
+	}
+	err = vc.Sys().Mount(TestBackend, &mountConfig)
+	if err != nil {
+		return cfg, client, err
+	}
+	return cfg, client, nil
+}
+
+func TeardownTestEnvironment() error {
+	return vc.Sys().Unmount(TestBackend)
+}


### PR DESCRIPTION
Ensure that tests always run on an empty backend. This ensures that tests can't influence each other.

(The usage of global variables for the config and the client is pretty ugly. I will fix this once this is merged.)