### PR TITLE
Always use absolute paths when VAULT_CLIENT_CONFIG is exported

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -124,7 +126,10 @@ func UpdateConfigToken(token string) error {
 
 func GetConfigPath() (string, error) {
 
-	path := os.Getenv("VAULT_CLIENT_CONFIG")
+	path, err := filepath.Abs(os.Getenv("VAULT_CLIENT_CONFIG"))
+	if err != nil {
+		return "", errors.New("Unable to determine absolute path to config specified in $VAULT_CLIENT_CONFIG")
+	}
 
 	if path != "" {
 		return path, nil


### PR DESCRIPTION
By default ~/.vaultrc is the configuration file which vc uses. You can override
this behaviour by exporting VAULT_CLIENT_CONFIG.

In case you don't specify an absolute path in VAULT_CLIENT_CONFIG the value will be joined with the
absolute path of the current working directory.