### PR TITLE
WIP: dockerize the vault-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go: 1.11.5
 
 sudo: required
 
+services:
+  - docker
+
 before_install:
   - export VAULT_VERSION=1.0.2
   - cp sample/vaultrc ~/.vaultrc
@@ -44,3 +47,8 @@ deploy:
     - vc
   on:
     tags: true
+
+deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker build . -t adfinissygroup/vc
+  - docker push adfinissygroup/vc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.11.5-alpine as builder
+
+WORKDIR /go/src
+
+ENV VERSION="1.1.4"
+
+RUN apk --update add alpine-sdk && \
+    curl -L -o- https://github.com/adfinis-sygroup/vault-client/archive/v${VERSION}.tar.gz  | tar xvzf - && \
+    cd vault-client-${VERSION} && \
+    make build  && mkdir /go/build && \
+    mv /go/src/vault-client-${VERSION}/vc /go/build/vc
+
+FROM alpine
+
+COPY --from=builder /go/build/vc /vc
+
+CMD ["/vc"]
+
+


### PR DESCRIPTION
Objective: Vault-client is being built in a docker-container and can be used via `docker run adfinissygroup/vc` 

Only the .vaultrc needs to be mapped to /root/.vaultrc inside the container.

change the travis.yml to also build and push the image.